### PR TITLE
fix argument check and remove default value in dmg command

### DIFF
--- a/ServerDevcommands/Commands/Dmg.cs
+++ b/ServerDevcommands/Commands/Dmg.cs
@@ -3,17 +3,18 @@ using System.Linq;
 using Service;
 
 namespace ServerDevcommands;
-///<summary>Applies damage or healing to nearby players.</summary>
+///<summary>Applies damage or healing to players.</summary>
 public class DmgCommand
 {
     public DmgCommand()
     {
-        Helper.Command("dmg", "[target] [value] - Default value: 5. (Negative values heal the character).", (args) =>
+        Helper.Command("dmg", "[target] [amount] - (Negative values heal the character).", (args) =>
         {
-            Helper.ArgsCheck(args, 1, "Missing target.");
-            Helper.ArgsCheck(args, 2, "Missing amount.");
+            Helper.ArgsCheck(args, 2, "Missing target.");
+            Helper.ArgsCheck(args, 3, "Missing amount.");
+            
             var name = args.Args[1];
-            var dmg = Parse.Float(args.Args[2], 5f);
+            var dmg = Parse.Float(args.Args[2], 0f);
 
             var absDmg = Math.Abs(dmg);
             var action = dmg >= 0 ? " damage" : " healing";

--- a/ServerDevcommands/Commands/Dmg.cs
+++ b/ServerDevcommands/Commands/Dmg.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 namespace ServerDevcommands;
+///<summary>Applies damage or healing to nearby players.</summary>
 public class DmgCommand
 {
     public DmgCommand()
@@ -59,8 +60,8 @@ public class DmgCommand
         });
         AutoComplete.Register("dmg", (int index) =>
         {
-            if (index == 0) return new List<string> { "others", "all" }.Concat(ParameterInfo.PlayerNames.Select(name => name.Contains(" ") ? $"\"{name}\"" : name)).ToList();
-            if (index >= 1) return ParameterInfo.Create("Value", "Positive = damage / Negative = healing");
+            if (index == 0) return new List<string> { "others", "all" }.Concat(ParameterInfo.PlayerNames).ToList();
+            if (index == 1) return ParameterInfo.Create("Value", "Positive = damage / Negative = healing");
             return ParameterInfo.None;
         });
     }


### PR DESCRIPTION
I don't know why, but ArgsCheck counts the command (dmg) itself as the first argument.
I also removed the default value because it becomes obsolete when checking a second argument.