### PR TITLE
Bufixes for Console caret reset and debugFly quaternion error spam

### DIFF
--- a/ServerDevcommands/Bugfixes.cs
+++ b/ServerDevcommands/Bugfixes.cs
@@ -1,0 +1,53 @@
+﻿using HarmonyLib;
+using System;
+using TMPro;
+using UnityEngine;
+
+namespace ServerDevcommands;
+
+// Fixes console from resetting caret position at start when deleting a selection range
+// happens first time opening console, or browsing commands history
+[HarmonyPatch(typeof(TMP_InputField), "KeyPressed")]
+public class TerminalFix
+{
+  static int caretPos = 0;
+  static int textLen = 0;
+  static int anchorPos = 0;
+
+  static void Prefix(TMP_InputField __instance)
+  {
+    TMP_InputField input = __instance;
+    textLen = input.text.Length;
+    caretPos = input.caretPosition;
+    anchorPos = input.selectionAnchorPosition;
+  }
+
+  static void Postfix(TMP_InputField __instance, Event evt)
+  {
+    TMP_InputField input = __instance;
+    if (caretPos == anchorPos) return; // only need workaround for selections
+
+    // first case: caret back to start
+    if (input.caretPosition == 0 && (evt.keyCode == KeyCode.Delete || evt.keyCode == KeyCode.Backspace))
+    {
+      if (textLen != input.text.Length)
+        input.caretPosition = Math.Min(Math.Min(caretPos, anchorPos), textLen);
+    }
+    
+    // second case: when caret is moved at 1 while typing with an active selection
+    if (input.caretPosition == 1 && (evt.character != 0))
+    {
+      input.caretPosition = Math.Min(Math.Min(caretPos, anchorPos), textLen) + 1; // position after typed character
+    }
+  }
+}
+
+// Fixes the rotation quaternion spam error while flying
+[HarmonyPatch(typeof(Character), nameof(Character.UpdateEyeRotation))]
+public class UpdateEyeRotationFix
+{
+  static void Prefix(Character __instance)
+  {
+    __instance.m_lookDir = __instance.m_lookDir.normalized;
+  }
+}

--- a/ServerDevcommands/ServerDevcommands.csproj
+++ b/ServerDevcommands/ServerDevcommands.csproj
@@ -21,6 +21,9 @@
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>..\..\Libs\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
+    <Reference Include="UnityEngine.IMGUIModule">
+      <HintPath>..\..\..\valheim_Data\managed\UnityEngine.IMGUIModule.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEngine.UI">
       <HintPath>..\..\Libs\UnityEngine.UI.dll</HintPath>
     </Reference>


### PR DESCRIPTION
This applies bugfixes for two annoying bugs from Valheim itself.

The console cursor position reset  when the text input is initialized when opening console or going up/down through command history, tirggered by deleting a text selection the first time.

I would have wished to make it even more surgical and figure out what on the TMP_InputField is failing to update its internal state for the caret position to behave correctly from the start, but I lost my patience.

The debugfly fix just renormalizes the `m_lookDir` quaternion that sometimes gets screwed up for unkown reasons.

I based this PR  on the December commit.