### PR TITLE
Fix private chest response patch for Valheim 1.0

### DIFF
--- a/ServerDevcommands/Features/AccessPrivateChests.cs
+++ b/ServerDevcommands/Features/AccessPrivateChests.cs
@@ -7,7 +7,7 @@ public class AccessPrivateChests
   static bool CheckAccess(bool result) => result || Settings.AccessPrivateChests;
 
 
-  [HarmonyPatch(nameof(Container.RPC_OpenRespons)), HarmonyPrefix]
-  static void RPC_OpenRespons(ref bool granted) => granted |= Settings.AccessPrivateChests;
+  [HarmonyPatch(nameof(Container.RPC_OpenResponse)), HarmonyPrefix]
+  static void RPC_OpenResponse(ref bool granted) => granted |= Settings.AccessPrivateChests;
 }
 


### PR DESCRIPTION
On Valheim 1.0.7, `AccessPrivateChests` fails to apply its Harmony prefix because `Container.RPC_OpenRespons` has been renamed to `Container.RPC_OpenResponse`. This updates the patch target and prefix method name to match the current game API.

The `granted` override and the existing `Settings.AccessPrivateChests` permission/configuration check are unchanged.

Validation:
- Compiled the affected source file in isolation against publicized Valheim 1.0.7 references: the previous version fails with CS0117 for `RPC_OpenRespons`; the updated version compiles.
- Checked the compiled Harmony attribute against the original game assembly: it resolves to exactly one `RPC_OpenResponse(long uid, bool granted)` method, and the prefix's `ref bool granted` parameter matches.
- Ran the actual prefix and access postfix in an isolated harness, supplying the effective setting through a stub. All four combinations of original result and enabled/disabled setting retain their existing behavior. This does not test the permission resolver itself.
- `git diff --check` passed.

Full-project build, Harmony patch installation in Unity, and multiplayer chest behavior have not been validated. This is a focused fix for the renamed RPC, not a claim of complete Valheim 1.0 compatibility.
